### PR TITLE
Improve approach to pluralising in templates

### DIFF
--- a/resources/lang/en/editorial.php
+++ b/resources/lang/en/editorial.php
@@ -22,8 +22,7 @@ return [
     ],
     'collections' => [
         'heading' => ':name collections',
-        'description' => ' The :collection_number registered collections for :name are shown below',
-        'description_singular' => ' The :collection_number registered collection for :name are shown below',
+        'description' => 'The :collection_number registered collection for :name is shown below | The :collection_number registered collections for :name are shown below',
         'breadcrumb_active' => 'Collections',
         'show' => [
             'heading' => 'Series related to the Leveson Inquiry',

--- a/resources/views/collections/index.blade.php
+++ b/resources/views/collections/index.blade.php
@@ -8,11 +8,7 @@
     <h1 class="page-header">{{ trans('editorial.collections.heading', ['name' => Auth::user()->department->name]) }} <a
                 href="{{ route('collections.create') }}"
                 class="btn btn-default pull-right">{{ trans('editorial.collections.create.title') }}</a></h1>
-    @if(count($collections) === 1)
-        <p>{{ trans('editorial.collections.description_singular', ['collection_number' => count($collections), 'name' => Auth::user()->department->name]) }}</p>
-    @else
-        <p>{{ trans('editorial.collections.description', ['collection_number' => count($collections), 'name' => Auth::user()->department->name]) }}</p>
-    @endif
+    <p>{{ trans_choice('editorial.collections.description', count($collections), ['collection_number' => count($collections), 'name' => Auth::user()->department->name]) }}</p>
     <div class="row">
         @foreach($collections as $collection)
             <div class="col-sm-6 col-md-4">


### PR DESCRIPTION
This replaces the approach of using conditionals in templates to
render alternative HTML to using Laravel's trans_choice() method
to select an appropriate option based on the number of items. This
approach has several benefits, including:

- Removing logic from views and therefore simplifying them
- Using an existing feature of the framework for its intended purpose
- Simplifying the localisation file by keeping related options together